### PR TITLE
workaround for binding issue with node 0.10.x

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,8 @@ util.inherits(Client, EventEmitter);
 module.exports = Client;
 
 Client.prototype.bind = function(host) {
-    this.client.bind(68, host);
-    this.client.setBroadcast(true);
+	var _this = this;
+    this.client.bind(68, host, function() { 
+    	_this.client.setBroadcast(true);
+    });
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -27,6 +27,8 @@ util.inherits(Server, EventEmitter);
 module.exports = Server;
 
 Server.prototype.bind = function(host) {
-    this.server.bind(67, host);
-    this.server.setBroadcast(true);
+	var _this = this;
+    this.server.bind(67, host, function() { 
+    	_this.server.setBroadcast(true);
+    });
 }


### PR DESCRIPTION
Workaround for binding issue "Error: bind EINVAL" with node 0.10.x on windows 64 bit
