### PR TITLE
Handle DHCP option 82 (relayAgentInformation)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -20,12 +20,12 @@ module.exports.parse = function(msg, rinfo) {
     function readIp(msg, offset, obj, name) {
         var len = msg.readUInt8(offset++);
         assert.strictEqual(len, 4);
-        p.options[name] = readIpRaw(msg, offset);
+        obj[name] = readIpRaw(msg, offset);
         return offset + len;
     }
     function readString(msg, offset, obj, name) {
         var len = msg.readUInt8(offset++);
-        p.options[name] = msg.toString('ascii', offset, offset + len);
+        obj[name] = msg.toString('ascii', offset, offset + len);
         offset += len;
         return offset;
     }
@@ -42,7 +42,7 @@ module.exports.parse = function(msg, rinfo) {
     }
     function readHex(msg, offset, obj, name) {
         var len = msg.readUInt8(offset++);
-        p.options[name] = readHexRaw(msg, offset, len);
+        obj[name] = readHexRaw(msg, offset, len);
         offset += len;
         return offset;
     }
@@ -83,7 +83,7 @@ module.exports.parse = function(msg, rinfo) {
             case 0: continue;   // pad
             case 255: break;    // end
             case 1: {           // subnetMask
-                offset = readIp(msg, offset, p, 'subnetMask');
+                offset = readIp(msg, offset, p.options, 'subnetMask');
                 break;
             }
             case 2: {           // timeOffset
@@ -128,11 +128,11 @@ module.exports.parse = function(msg, rinfo) {
                 break;
             }
             case 12: {          // hostName
-                offset = readString(msg, offset, p, 'hostName');
+                offset = readString(msg, offset, p.options, 'hostName');
                 break;
             }
             case 15: {          // domainName
-                offset = readString(msg, offset, p, 'domainName');
+                offset = readString(msg, offset, p.options, 'domainName');
                 break;
             }
             case 43: {          // vendorOptions
@@ -149,7 +149,7 @@ module.exports.parse = function(msg, rinfo) {
                 break;
             }
             case 50: {          // requestedIpAddress
-                offset = readIp(msg, offset, p, 'requestedIpAddress');
+                offset = readIp(msg, offset, p.options, 'requestedIpAddress');
                 break;
             }
             case 51: {          // ipAddressLeaseTime
@@ -176,7 +176,7 @@ module.exports.parse = function(msg, rinfo) {
                 break;
             }
             case 54: {          // serverIdentifier
-                offset = readIp(msg, offset, p, 'serverIdentifier');
+                offset = readIp(msg, offset, p.options, 'serverIdentifier');
                 break;
             }
             case 55: {          // parameterRequestList
@@ -210,7 +210,8 @@ module.exports.parse = function(msg, rinfo) {
                 break;
             }
             case 60: {          // vendorClassIdentifier
-                offset = readString(msg, offset, p, 'vendorClassIdentifier');
+                offset = readString(msg, offset, p.options,
+                                    'vendorClassIdentifier');
                 break;
             }
             case 61: {          // clientIdentifier
@@ -284,7 +285,7 @@ module.exports.parse = function(msg, rinfo) {
                 break;
             }
             case 118: {		    // subnetSelection
-                offset = readIp(msg, offset, p, 'subnetAddress');
+                offset = readIp(msg, offset, p.options, 'subnetAddress');
                 break;
             }
             default: {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -40,6 +40,20 @@ module.exports.parse = function(msg, rinfo) {
         }
         return addr;
     }
+    function readHex(msg, offset, obj, name) {
+        var len = msg.readUInt8(offset++);
+        p.options[name] = readHexRaw(msg, offset, len);
+        offset += len;
+        return offset;
+    }
+    function readHexRaw(msg, offset, len) {
+        var data = '';
+        while (len-- > 0) {
+            var b = msg.readUInt8(offset++);
+            data += (b + 0x100).toString(16).substr(-2);
+        }
+        return data;
+    }
     //console.log(rinfo.address + ':' + rinfo.port + '/' + msg.length + 'b');
     var p = {
         op: protocol.BOOTPMessageType.get(msg.readUInt8(0)),
@@ -215,6 +229,58 @@ module.exports.parse = function(msg, rinfo) {
                     name: msg.toString('ascii', offset + 3, offset + len)
                 };
                 offset += len;
+                break;
+            }
+            case 82: {          // relayAgentInformation           (RFC 3046)
+                var len = msg.readUInt8(offset++);
+                p.options.relayAgentInformation = {};
+                var cur = offset;
+                offset += len;
+                while (cur < offset) {
+                    var subopt = msg.readUInt8(cur++);
+                    switch (subopt) {
+                        case 1: {   // agentCircuitId              (RFC 3046)
+                            cur = readHex(msg, cur,
+                                          p.options.relayAgentInformation,
+                                          'agentCircuitId');
+                            break;
+                        }
+                        case 2: {   // agentRemoteId               (RFC 3046)
+                            cur = readHex(msg, cur,
+                                          p.options.relayAgentInformation,
+                                          'agentRemoteId');
+                            break;
+                        }
+                        case 4: {   // docsisDeviceClass           (RFC 3256)
+                            var sublen = msg.readUInt8(cur++);
+                            assert.strictEqual(sublen, 4);
+                            p.options.relayAgentInformation.docsisDeviceClass =
+                                msg.readUInt32(cur);
+                            cur += sublen;
+                            break;
+                        }
+                        case 5: {   // linkSelection               (RFC 3527)
+                            assert.strictEqual(sublen, 4);
+                            cur = readIp(msg, cur,
+                                         p.options.relayAgentInformation,
+                                         'linkSelectionSubnet');
+                            break;
+                        }
+                        case 6: {   // subscriberId                (RFC 3993)
+                            cur = readString(msg, cur,
+                                             p.options.relayAgentInformation,
+                                             'subscriberId');
+                            break;
+                        }
+                        default: {
+                            console.log('Unhandled DHCP option 82 sub-option ' +
+                                        subopt + ", len " + sublen);
+                            var sublen = msg.readUInt8(cur++);
+                            cur += sublen;
+                            break;
+                        }
+                    }
+                }
                 break;
             }
             case 118: {		    // subnetSelection


### PR DESCRIPTION
- Parse DHCP option 82 from RFC 3046, attempting to parse sub-options
- Handle sub-options 1 (agentCircuitId), 2 (agentRemoteId) from RFC 3046
- Handle sub-option 4 (docsisDeviceClass) from RFC 3256
- Handle sub-option 5 (linkSelectionSubnet) from RFC 3527
- Handle sub-option 6 (subscriberId) from RFC 3993
- Skip unknown sub-options and log to the console

Fixes #12 