### PR TITLE
Added support for WPAD responses (option 252)

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -288,6 +288,10 @@ module.exports.parse = function(msg, rinfo) {
                 offset = readIp(msg, offset, p.options, 'subnetAddress');
                 break;
             }
+            case 252: {        // The Web Proxy Auto Discovery (WPAD)
+                offset = readString(msg, offset, p.options, 'wpadUrl');
+                break;
+            }
             default: {
                 var len = msg.readUInt8(offset++);
                 console.log('Unhandled DHCP option ' + code + '/' + len + 'b');


### PR DESCRIPTION
Hi,

I need this for a project of mine, where I am trying to automatically detect the proxy as configured in the LAN. The URL to the Proxy Auto Configuration file is distributed through option 252 in DHCP.

So could you please see if this is something that you could merge to main?

Best Regards
    //Jan Flyborg
