### PR TITLE
Changed createDiscoverPacket to createPacket to fix absence of ciaddr.

### DIFF
--- a/example-dhcpinform.js
+++ b/example-dhcpinform.js
@@ -59,8 +59,8 @@ for (var interface in interfaces) {
                     clientIdentifier: 'MyMachine',
                 }
             }
-            var discover = client.createPacket(pkt);
-            client.broadcastPacket(discover, undefined, function() {
+            var inform = client.createPacket(pkt);
+            client.broadcastPacket(inform, undefined, function() {
                 console.log('dhcpInform ['+interface+': '+pkt.ciaddr+']: sent');
             });
         }

--- a/example-dhcpinform.js
+++ b/example-dhcpinform.js
@@ -59,7 +59,7 @@ for (var interface in interfaces) {
                     clientIdentifier: 'MyMachine',
                 }
             }
-            var discover = client.createDiscoverPacket(pkt);
+            var discover = client.createPacket(pkt);
             client.broadcastPacket(discover, undefined, function() {
                 console.log('dhcpInform ['+interface+': '+pkt.ciaddr+']: sent');
             });


### PR DESCRIPTION
The original example-dhcpinform didn't work for me because it used the createDiscoverPacket method of client.js, which (quite rightly) doesn't send the ciaddr. So I have changed it to use the createPacket method instead.