### PR TITLE
Fixed a misnamed variable

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -108,7 +108,7 @@ Client.prototype.createPacket = function(pkt) {
     if (pkt.options && 'requestedIpAddress' in pkt.options) {
         p.writeUInt8(50, i++); // option 50
         var requestedIpAddress = new Buffer(
-            new v4.Address(pkt.options.requestedIpAddress).toArray());
+            new V4Address(pkt.options.requestedIpAddress).toArray());
         p.writeUInt8(requestedIpAddress.length, i++);
         requestedIpAddress.copy(p, i); i += requestedIpAddress.length;
     }
@@ -120,7 +120,7 @@ Client.prototype.createPacket = function(pkt) {
     if (pkt.options && 'serverIdentifier' in pkt.options) {
         p.writeUInt8(54, i++); // option 54
         var serverIdentifier = new Buffer(
-            new v4.Address(pkt.options.serverIdentifier).toArray());
+            new V4Address(pkt.options.serverIdentifier).toArray());
         p.writeUInt8(serverIdentifier.length, i++);
         serverIdentifier.copy(p, i); i += serverIdentifier.length;
     }


### PR DESCRIPTION
Fixed a misnamed variable:
"V4Address" was erroneously used as "v4.Address".

