### PR TITLE
Add 'vendorOptions' to client.createPacket

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -142,6 +142,14 @@ Client.prototype.createPacket = function(pkt) {
         p.writeUInt8(0, i++);            // hardware type 0
         clientIdentifier.copy(p, i); i += clientIdentifier.length;
     }
+    if (pkt.options && 'vendorOptions' in pkt.options){
+        for ( var key in pkt.options.vendorOptions) {
+            var value = pkt.options.vendorOptions[key];
+            p.writeUInt8(parseInt(key), i++); // option 'key'
+            p.writeUInt8(value.length, i++); // length
+            value.copy(p, i); i += value.length;
+        }
+    }
 
     // option 255 - end
     p.writeUInt8(0xff, i++);


### PR DESCRIPTION
Add 'vendorOptions' to client.createPacket. Like the readme suggests:

> `
options: 
>    { ...
>      vendorOptions: { '220': <Buffer 00> } } }`