### PR TITLE
Emitting 'error' on parsing failure

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -19,10 +19,12 @@ function Server(options) {
     this.server = dgram.createSocket('udp4');
     this.server.on('message', function(msg, rinfo) {
       try {
-          var data = parser.parse( msg, rinfo );
-          self.emit('message',data);
+          var data = parser.parse(msg, rinfo);
+          self.emit('message', data);
       } catch (e) {
-          self.emit('error',e);
+          if (!self.emit('error', e)) {
+              throw e;
+          }
       }
     });
     this.server.on('listening', function() {


### PR DESCRIPTION
In order to handle with dhcp parsing errors would be useful to set up something like:

        var server = dhcpjs.createServer();

        server.on('listening', onListening);
        server.on('message', handleMessage);
        server.on('error', handleError);
        server.bind();

I'm proposing a patch to emit the 'error' event in those cases
